### PR TITLE
[sc-96495]: polish and document the workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - id: config
         run: echo "artefact_name=qt-${{ env.qt_version }}-src.tar.gz" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: qt/qt5
           ref: v${{ env.qt_version }}
@@ -49,7 +49,7 @@ jobs:
       - name: Archive
         run: tar --create --xz --file "${{ steps.config.outputs.artefact_name }}" --exclude-vcs qt-src
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.config.outputs.artefact_name }}"
           path: "${{ github.workspace }}/${{ steps.config.outputs.artefact_name }}"
@@ -127,7 +127,7 @@ jobs:
             libxslt-dev \
             libxss-dev \
             libxtst-dev \
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: qt/qt5
           ref: v${{ env.qt_version }}
@@ -178,7 +178,7 @@ jobs:
         working-directory: ${{ github.workspace }}/opt
         run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qt5
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.config.outputs.artefact_name }}"
           path: "${{ github.workspace }}/opt/${{ steps.config.outputs.artefact_name }}"
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         env:
           artefact_name: qt-${{ env.qt_version }}-${{ matrix.config.artefact }}.tar.gz 
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,9 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: "ubuntu-18.04"
-            # doesn't matter what we ask for, this is what we get...
-            std: "17"
           - os: "ubuntu-22.04"
             std: "17"
 
@@ -217,7 +214,6 @@ jobs:
       matrix:
         config:
           - artefact: src
-          - artefact: cpp17-ubuntu-18.04-x64
           - artefact: cpp17-ubuntu-22.04-x64
     needs: release
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ name: CI
 # licence (the Qt website reports it isn't, although this 5.15.8 includes an
 # LGPL licence).
 
+env:
+  # The version of QT that should get built
+  # This will need to match the tags used in the qt/qt5 repo minus the "v"
+  # For example this version will use source from qt/qt5 tag "v5.15.8-lts-lgpl"
+  qt_version: "5.15.8-lts-lgpl"
+
 on:
   pull_request:
     branches: [main]
@@ -29,20 +35,15 @@ on:
 
 jobs:
   tar-src:
-    name: "Tar ${{ matrix.config.qt }} source"
+    name: "Tar qt source"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - qt: "5.15.8-lts-lgpl"
     steps:
       - id: config
-        run: echo "artefact_name=qt-${{ matrix.config.qt }}-src.tar.gz" >> $GITHUB_OUTPUT
+        run: echo "artefact_name=qt-${{ env.qt_version }}-src.tar.gz" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           repository: qt/qt5
-          ref: v${{ matrix.config.qt }}
+          ref: v${{ env.qt_version }}
           submodules: true
           path: qt-src
       - name: Archive
@@ -63,15 +64,13 @@ jobs:
           - os: "ubuntu-18.04"
             # doesn't matter what we ask for, this is what we get...
             std: "17"
-            qt: "5.15.8-lts-lgpl"
           - os: "ubuntu-22.04"
             std: "17"
-            qt: "5.15.8-lts-lgpl"
 
     steps:
       - id: config
         run: |
-          artefact_name="qt-${{ matrix.config.qt }}-cpp${{ matrix.config.std }}-${{ matrix.config.os }}-x64.tar.gz"
+          artefact_name="qt-${{ env.qt_version }}-cpp${{ matrix.config.std }}-${{ matrix.config.os }}-x64.tar.gz"
           echo "artefact_name=$artefact_name" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: |
@@ -131,7 +130,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: qt/qt5
-          ref: v${{ matrix.config.qt }}
+          ref: v${{ env.qt_version }}
           submodules: true
       - name: Configure
         run: |
@@ -217,25 +216,28 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - artefact: qt-5.15.8-lts-lgpl-src.tar.gz
-          - artefact: qt-5.15.8-lts-lgpl-cpp17-ubuntu-18.04-x64.tar.gz
-          - artefact: qt-5.15.8-lts-lgpl-cpp17-ubuntu-22.04-x64.tar.gz
+          - artefact: src
+          - artefact: cpp17-ubuntu-18.04-x64
+          - artefact: cpp17-ubuntu-22.04-x64
     needs: release
 
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3
+        env:
+          artefact_name: qt-${{ env.qt_version }}-${{ matrix.config.artefact }}.tar.gz 
         with:
-          name: "${{ matrix.config.artefact }}"
+          name: "${{ env.artefact_name }}"
           path: ./
       - name: Upload to Release
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          artefact_name: qt-${{ env.qt_version }}-${{ matrix.config.artefact }}.tar.gz 
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: "./${{ matrix.config.artefact }}"
-          asset_name: "${{ matrix.config.artefact }}"
+          asset_path: "./${{ env.artefact_name }}"
+          asset_name: "${{ env.artefact_name }}"
           asset_content_type: application/x-gtar
 
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,47 @@
 This project builds the official, unmodified, Qt source code for C++17 using
 GitHub actions runners.
 
+## How to use this repo
 
-## Installation
+So you need to build a specific version of Qt. Here's how:
 
-Using `curl` to download and extract to `/opt/qt5`:
+1. create a branch for the version you want (use whatever name seems sensible)
+2. update `.github/workflows/main.yml` to specify the version of Qt you want to build
+3. create a PR with your changes. This will trigger the CI to do a test build
+4. debug any issues
+    1. check the action suceeded
+    2. check the artefacts it built are correct/work for you
+    3. keep tweaking `main.yml` until the action builds the version you want successfully
+5. once you have a successful build, tag the commit with the Qt version number to trigger a release build (`git tag v6.7.1 && git push --tags`)
+6. merge your PR (or rebase, up to you)
+
+Now to use the library you have built do something like:
+
+Use `curl` to download and extract to `/opt/qt5`:
 
     curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-$PLATFORM-x64.tar.gz | sudo tar -xJC /opt
 
 where `$PLATFORM` is `ubuntu-18.04` or `ubuntu-22.04`.
+
+
+## Details
+
+Here's some more info about how this repo works. It's basically just a workflow that pulls the Qt source code for a specific version, builds it, and then optionally produces a release.
+
+### The build
+
+The workflow will pull the Qt source code from the `qt/qt5` github repo. 
+We use the tags on this repo (eg `v6.7.1` or `v5.15.8-lts-lgpl`) when checking out to make sure we checkout a specific Qt version.
+The qt version specified at the top of the workflow file is this tag without the `v` prefix.
+
+### Trigger the build
+
+To trigger a build just create a PR and push to it. Every push will build Qt and provide the results as artefacts tied to the workflow run.
+
+### Trigger the release
+
+To trigger a release just push a tag that starts with `v`. Ideally push a tag matching the version of Qt you want to build a release for. The release will use the tag you provide to both tag and name the release (so tag `v1.2.3` will produce `Release v1.2.3` with tag `v1.2.3`).
+Simply pushing a tag will trigger the build process (on any branch), and then will create a Release using the result of that build. That release can be used via the `curl` process listed above.
+
+
+

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ So you need to build a specific version of Qt. Here's how:
     1. check the action suceeded
     2. check the artefacts it built are correct/work for you
     3. keep tweaking `main.yml` until the action builds the version you want successfully
-5. once you have a successful build, tag the commit with the Qt version number to trigger a release build (`git tag v6.7.1 && git push --tags`)
-6. merge your PR (or rebase, up to you)
+5. once you have a successful build, merge/rebase your PR into `main`
+6. Then tag the latest commit on `main` with the Qt version number to trigger a release build (`git tag v6.7.1 && git push --tags`)
 
 Now to use the library you have built do something like:
 
@@ -44,6 +44,3 @@ To trigger a build just create a PR and push to it. Every push will build Qt and
 
 To trigger a release just push a tag that starts with `v`. Ideally push a tag matching the version of Qt you want to build a release for. The release will use the tag you provide to both tag and name the release (so tag `v1.2.3` will produce `Release v1.2.3` with tag `v1.2.3`).
 Simply pushing a tag will trigger the build process (on any branch), and then will create a Release using the result of that build. That release can be used via the `curl` process listed above.
-
-
-


### PR DESCRIPTION
## Description

PR to update the workflow that builds Qt. General goals are:
- make it easier to update the qt version number
- update any github actions marked as deprecated
- make sure you can create test builds on a PR and release builds from main easily
- properly document the process for building Qt using this repo