### PR TITLE
Sc 96693/build qt6 7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,7 @@ jobs:
             -skip qtnetworkauth \
             -skip qtqa \
             -skip qtquick3d \
+            -skip qtquick3dphysics \
             -skip qtquicktimeline \
             -skip qtvirtualkeyboard \
             -skip qtwayland \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Configure
         run: |
           ./configure \
-            -prefix "${{ github.workspace }}/opt/qt5" \
+            -prefix "${{ github.workspace }}/opt/qt6" \
             -opensource -confirm-license \
             -c++std c++${{ matrix.config.std }} \
             -shared \
@@ -184,7 +184,7 @@ jobs:
           make install
       - name: Archive
         working-directory: ${{ github.workspace }}/opt
-        run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qt5
+        run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qt6
       - name: Upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,7 @@ jobs:
             -skip qtdatavis3d \
             -skip qtdoc \
             -skip qtdocgallery \
+            -skip qtgraphs \
             -skip qtlottie \
             -skip qtmultimedia \
             -skip qtnetworkauth \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,6 +165,7 @@ jobs:
             -skip qtquick3d \
             -skip qtquick3dphysics \
             -skip qtquicktimeline \
+            -skip qtspeech \
             -skip qtvirtualkeyboard \
             -skip qtwayland \
             -skip qtwebengine \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,8 @@ name: CI
 env:
   # The version of QT that should get built
   # This will need to match the tags used in the qt/qt5 repo minus the "v"
-  # For example this version will use source from qt/qt5 tag "v5.15.8-lts-lgpl"
-  qt_version: "5.15.8-lts-lgpl"
+  # For example this version will use source from qt/qt5 tag "v6.7.1"
+  qt_version: "6.7.1"
 
 on:
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,12 +87,15 @@ jobs:
             libegl1-mesa-dev \
             libfontconfig1-dev \
             libfreetype6-dev \
+            libglib2.0-dev \
             libglu1-mesa-dev \
+            libice-dev \
             libicu-dev \
             libjpeg-dev \
             libnss3-dev \
             libpng-dev \
             libpq-dev \
+            libsm-dev \
             libssl-dev \
             libudev-dev \
             libx11-dev \
@@ -102,6 +105,7 @@ jobs:
             libxcb-image0-dev \
             libxcb-keysyms1-dev \
             libxcb-randr0-dev \
+            libxcb-render0-dev \
             libxcb-render-util0-dev \
             libxcb-shape0-dev \
             libxcb-shm0-dev \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,13 @@ env:
 on:
   pull_request:
     branches: [main]
+    # Note: This ignores if the pull request as a whole only touches MD files.
+    # If ANY commit in the PR touches something else then every push will trigger this workflow.
     paths-ignore:
       - '**/*.md'
   push:
     tags:
       - v*
-    paths-ignore:
-      - '**/*.md'
 
 jobs:
   tar-src:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,7 @@ jobs:
             libudev-dev \
             libx11-dev \
             libx11-xcb-dev \
+            libxcb-cursor-dev \
             libxcb-glx0-dev \
             libxcb-icccm4-dev \
             libxcb-image0-dev \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,6 +166,7 @@ jobs:
             -skip qtquick3dphysics \
             -skip qtquicktimeline \
             -skip qtspeech \
+            -skip qttools \
             -skip qtvirtualkeyboard \
             -skip qtwayland \
             -skip qtwebengine \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,9 +164,11 @@ jobs:
             -skip qtqa \
             -skip qtquick3d \
             -skip qtquick3dphysics \
+            -skip qtquickeffectmaker \
             -skip qtquicktimeline \
             -skip qtspeech \
             -skip qttools \
+            -skip qttranslations \
             -skip qtvirtualkeyboard \
             -skip qtwayland \
             -skip qtwebengine \


### PR DESCRIPTION
## Description

PR to update the workflow to build Qt 6.7.1.
Includes updates to the readme to clarify the workflow.

Once this is approved I will trigger the official release build for Qt 6.7.1. Then it will be available for use in other repos in a stable state (this just means the release won't have "-test" appended to the name).